### PR TITLE
Set use_cache to False in create_rpmbuild_for_env function to fix bug…

### DIFF
--- a/conda_rpms/build_rpm_structure.py
+++ b/conda_rpms/build_rpm_structure.py
@@ -99,7 +99,7 @@ def create_rpmbuild_for_env(pkgs, target, config):
         os.makedirs(spec_dir)
 
     for source, pkg in pkgs:
-        index = conda.fetch.fetch_index([source], use_cache=True)
+        index = conda.fetch.fetch_index([source], use_cache=False)
         tar_name = pkg + '.tar.bz2'
         pkg_info = index.get(tar_name, None)
         if pkg_info is None:


### PR DESCRIPTION
… - wasn't able to find openssl-1.0.2h-1.tar.bz2 in conda channel https://repo.continuum.io/pkgs/free/linux-64/.
