### PR TITLE
Fix overwriting version in name_release_version

### DIFF
--- a/conda_rpms/build.py
+++ b/conda_rpms/build.py
@@ -14,11 +14,11 @@ def name_version_release(spec_fh):
     """
     content = {}
     for line in spec_fh:
-        if line.startswith('Name:'):
+        if line.startswith('Name:') and 'name' not in content:
             content['name'] = line[5:].strip()
-        elif line.startswith('Version:'):
+        elif line.startswith('Version:') and 'version' not in content:
             content['version'] = line[8:].strip()
-        elif line.startswith('Release:'):
+        elif line.startswith('Release:') and 'release' not in content:
             content['release'] = line[8:].strip()
     return content
 

--- a/conda_rpms/tests/unit/test_build.py
+++ b/conda_rpms/tests/unit/test_build.py
@@ -1,0 +1,42 @@
+import textwrap
+import unittest
+
+from conda_rpms.build import name_version_release
+
+
+class Test_name_version_release(unittest.TestCase):
+    def _check_output(self, spec):
+        expected = {'name': 'foo', 'release':'2', 'version':'1'}
+        actual = name_version_release(textwrap.dedent(spec).split('\n'))
+        self.assertEqual(expected, actual)
+
+    def test_multiple_names(self):
+        spec = """
+                Name: foo
+                Version: 1
+                Release: 2
+                Name: bar
+                """
+        self._check_output(spec)
+
+    def test_multiple_versions(self):
+        spec = """
+                Name: foo
+                Version: 1
+                Release: 2
+                Version: 3
+                """
+        self._check_output(spec)
+
+    def test_multiple_releases(self):
+        spec = """
+                Name: foo
+                Version: 1
+                Release: 2
+                Release: 3
+                """
+        self._check_output(spec)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Previously, if multiple lines starting with `Name:`, `Release:` or `Version:` appear in a file. `name_release_version` would save the last one found. Now it only saves the first.
